### PR TITLE
Add suspend() and resume() for MCP clients

### DIFF
--- a/src/main/php/io/modelcontextprotocol/McpClient.class.php
+++ b/src/main/php/io/modelcontextprotocol/McpClient.class.php
@@ -24,6 +24,26 @@ class McpClient implements Traceable {
     $this->capabilities= Capabilities::client();
   }
 
+  /** Suspends this MCP client for later continuation */
+  public function suspend(): array {
+    return [
+      'transport' => ['impl' => get_class($this->transport), 'suspended' => $this->transport->suspend()],
+      'version'   => $this->version,
+      'server'    => $this->server,
+    ];
+  }
+
+  /** Resumes a previously suspended transport */
+  public static function resume(array $suspended): self {
+    $self= new self(
+      $suspended['transport']['impl']::resume($suspended['transport']['suspended']),
+      $suspended['version']
+    );
+    $self->server= $suspended['server'];
+    return $self;
+  }
+
+
   /** @return io.modelcontextprotocol.Transport */
   public function transport() { return $this->transport; }
 


### PR DESCRIPTION
This allows to resume an MCP HTTP server session when re-connecting. When resuming, the protocol initialization can be omitted, thus saving multiple roundtrips.

```php
use use io\modelcontextprotocol\McpClient;

$suspens= 'suspense.json';
if (file_exists($suspense)) {
  $client= McpClient::resume(json_decode(file_get_contents($suspense), true));
} else {
  $client= new McpClient($argv[1]);
}

// [...call tools etcetera...]

file_put_contents($suspense, json_encode($client->suspend()));
```
