### PR TITLE
Support multiple delegates via `Delegates` class

### DIFF
--- a/src/main/php/io/modelcontextprotocol/McpServer.class.php
+++ b/src/main/php/io/modelcontextprotocol/McpServer.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\modelcontextprotocol;
 
-use io\modelcontextprotocol\server\{Delegate, Delegates, InstanceDelegate, JsonRpc, Response};
+use io\modelcontextprotocol\server\{Delegate, JsonRpc, Response};
 use lang\FormatException;
 use text\json\Json;
 use util\NoSuchElementException;
@@ -12,18 +12,16 @@ class McpServer implements Handler, Traceable {
   private $delegate, $version, $capabilities, $rpc;
   private $cat= null;
 
+  /**
+   * Creates a new MCP server
+   *
+   * @param  object|array|io.modelcontextprotocol.server.Delegate $arg
+   * @param  string $version
+   */
   public function __construct($arg, string $version= '2025-06-18') {
-    if ($arg instanceof Delegate) {
-      $this->delegate= $arg;
-    } else if (is_array($arg)) {
-      $this->delegate= new Delegates(...$arg);
-    } else {
-      $this->delegate= new InstanceDelegate($arg);
-    }
-
+    $this->delegate= Delegate::from($arg);
     $this->version= $version;
     $this->capabilities= Capabilities::server();
-
     $this->rpc= new JsonRpc([
       'initialize' => function() {
         return new Response(200, ['Mcp-Session-Id' => uniqid(microtime(true))], [

--- a/src/main/php/io/modelcontextprotocol/server/Delegate.class.php
+++ b/src/main/php/io/modelcontextprotocol/server/Delegate.class.php
@@ -1,0 +1,102 @@
+<?php namespace io\modelcontextprotocol\server;
+
+use lang\reflection\Type;
+use util\Bytes;
+
+/** Base class for InstanceDelegate, Delegates and ImplementationsIn */ 
+abstract class Delegate {
+
+  /**
+   * Finds a readable resource
+   *
+   * @param  string $tool
+   * @return ?[:var]
+   */
+  public abstract function readable($uri);
+
+  /**
+   * Finds an invokeable tool
+   *
+   * @param  string $tool
+   * @return ?function(var[]): var
+   */
+  public abstract function invokeable($tool);
+
+  /** Yields all tools in a given type */
+  protected function toolsIn(Type $type, string $namespace): iterable {
+    foreach ($type->methods()->annotated(Tool::class) as $name => $method) {
+      $properties= $required= [];
+      foreach ($method->parameters() as $param => $reflect) {
+        $annotations= $reflect->annotations();
+        if ($annotation= $annotations->type(Param::class)) {
+          $properties[$param]= $annotation->newInstance()->schema();
+        } else {
+          $properties[$param]= ['type' => 'string', 'description' => ucfirst($param)];
+        }
+        $reflect->optional() || $required[]= $param;
+      }
+
+      yield [
+        'name'        => $namespace.'_'.$name,
+        'description' => $method->comment() ?? null,
+        'inputSchema' => [
+          'type'       => 'object',
+          'properties' => $properties ?: (object)[],
+          'required'   => $required,
+        ],
+      ];
+    }
+  }
+
+  /** Yields all prompts in a given type */
+  protected function promptsIn(Type $type, string $namespace): iterable {
+    foreach ($type->methods()->annotated(Prompt::class) as $name => $method) {
+      $arguments= [];
+      foreach ($method->parameters() as $param => $reflect) {
+        if ($annotation= $reflect->annotation(Param::class)) {
+          $schema= $annotation->newInstance()->schema();
+          $description= $schema['description'] ?? null;
+          unset($schema['description']);
+        } else {
+          $schema= [];
+          $description= null;
+        }
+        $arguments[]= [
+          'name'        => $param,
+          'description' => $description ?? ucfirst($param),
+          'required'    => !$reflect->optional(),
+          'schema'      => $schema ?? ['type' => 'string'],
+        ];
+      }
+
+      yield [
+        'name'        => $namespace.'_'.$name,
+        'description' => $method->comment() ?? null,
+        'arguments'   => $arguments,
+      ];
+    }
+  }
+
+  /** Yields all resources in a given type */
+  protected function resourcesIn(Type $type, string $namespace, bool $templates): iterable {
+    foreach ($type->methods() as $name => $method) {
+      if ($annotation= $method->annotation(Resource::class)) {
+        $resource= $annotation->newInstance();
+        $templates === $resource->template && yield $resource->meta + [
+          'name'        => $namespace.'_'.$name,
+          'description' => $method->comment() ?? null,
+        ];
+      }
+    }
+  }
+
+  /** Returns contents of a given resource */
+  protected function contentsOf(string $uri, string $mimeType, $result) {
+    return [
+      ['uri' => $uri, 'mimeType' => $mimeType] + ($result instanceof Bytes
+        ? ['blob' => base64_encode($result)]
+        : ['text' => $result]
+      )
+    ];
+  }
+}

--- a/src/main/php/io/modelcontextprotocol/server/Delegate.class.php
+++ b/src/main/php/io/modelcontextprotocol/server/Delegate.class.php
@@ -6,6 +6,17 @@ use util\Bytes;
 /** Base class for InstanceDelegate, Delegates and ImplementationsIn */ 
 abstract class Delegate {
 
+  /** @param object|array|io.modelcontextprotocol.server.Delegate $arg */
+  public static function from($arg): self {
+    if ($arg instanceof self) {
+      return $arg;
+    } else if (is_array($arg)) {
+      return new Delegates($arg);
+    } else {
+      return new InstanceDelegate($arg);
+    }
+  }
+
   /**
    * Finds a readable resource
    *

--- a/src/main/php/io/modelcontextprotocol/server/Delegates.class.php
+++ b/src/main/php/io/modelcontextprotocol/server/Delegates.class.php
@@ -2,10 +2,19 @@
 
 /** @see io.modelcontextprotocol.unittest.DelegatesTest */
 class Delegates extends Delegate {
-  private $delegates;
+  private $delegates= [];
 
-  public function __construct(parent... $delegates) {
-    $this->delegates= $delegates;
+  /** @param (object|array|io.modelcontextprotocol.server.Delegate)[]|[:object] $args */
+  public function __construct(array $args) {
+    if (0 === key($args)) {
+      foreach ($args as $arg) {
+        $this->delegates[]= parent::from($arg);
+      }
+    } else {
+      foreach ($args as $namespace => $arg) {
+        $this->delegates[]= new InstanceDelegate($arg, $namespace);
+      }
+    }
   }
 
   /** Finds a readable resource */

--- a/src/main/php/io/modelcontextprotocol/server/Delegates.class.php
+++ b/src/main/php/io/modelcontextprotocol/server/Delegates.class.php
@@ -1,84 +1,47 @@
 <?php namespace io\modelcontextprotocol\server;
 
-use lang\reflection\Type;
-use util\Bytes;
+/** @see io.modelcontextprotocol.unittest.DelegatesTest */
+class Delegates extends Delegate {
+  private $delegates;
 
-abstract class Delegates {
+  public function __construct(parent... $delegates) {
+    $this->delegates= $delegates;
+  }
 
-  /** Yields all tools in a given type */
-  protected function toolsIn(Type $type, string $namespace): iterable {
-    foreach ($type->methods()->annotated(Tool::class) as $name => $method) {
-      $properties= $required= [];
-      foreach ($method->parameters() as $param => $reflect) {
-        $annotations= $reflect->annotations();
-        if ($annotation= $annotations->type(Param::class)) {
-          $properties[$param]= $annotation->newInstance()->schema();
-        } else {
-          $properties[$param]= ['type' => 'string', 'description' => ucfirst($param)];
-        }
-        $reflect->optional() || $required[]= $param;
-      }
+  /** Finds a readable resource */
+  public function readable($uri) {
+    foreach ($this->delegates as $delegate) {
+      if ($contents= $delegate->readable($uri)) return $contents;
+    }
+    return null;
+  }
 
-      yield [
-        'name'        => $namespace.'_'.$name,
-        'description' => $method->comment() ?? null,
-        'inputSchema' => [
-          'type'       => 'object',
-          'properties' => $properties ?: (object)[],
-          'required'   => $required,
-        ],
-      ];
+  /** Finds an invokeable tool */
+  public function invokeable($tool) {
+    foreach ($this->delegates as $delegate) {
+      if ($callable= $delegate->invokeable($tool)) return $callable;
+    }
+    return null;
+  }
+
+  /** Returns all tools */
+  public function tools(): iterable {
+    foreach ($this->delegates as $delegate) {
+      yield from $delegate->tools();
     }
   }
 
-  /** Yields all prompts in a given type */
-  protected function promptsIn(Type $type, string $namespace): iterable {
-    foreach ($type->methods()->annotated(Prompt::class) as $name => $method) {
-      $arguments= [];
-      foreach ($method->parameters() as $param => $reflect) {
-        if ($annotation= $reflect->annotation(Param::class)) {
-          $schema= $annotation->newInstance()->schema();
-          $description= $schema['description'] ?? null;
-          unset($schema['description']);
-        } else {
-          $schema= [];
-          $description= null;
-        }
-        $arguments[]= [
-          'name'        => $param,
-          'description' => $description ?? ucfirst($param),
-          'required'    => !$reflect->optional(),
-          'schema'      => $schema ?? ['type' => 'string'],
-        ];
-      }
-
-      yield [
-        'name'        => $namespace.'_'.$name,
-        'description' => $method->comment() ?? null,
-        'arguments'   => $arguments,
-      ];
+  /** Returns all prompts */
+  public function prompts(): iterable {
+    foreach ($this->delegates as $delegate) {
+      yield from $delegate->prompts();
     }
   }
 
-  /** Yields all resources in a given type */
-  protected function resourcesIn(Type $type, string $namespace, bool $templates): iterable {
-    foreach ($type->methods() as $name => $method) {
-      if ($annotation= $method->annotation(Resource::class)) {
-        $resource= $annotation->newInstance();
-        $templates === $resource->template && yield $resource->meta + [
-          'name'        => $namespace.'_'.$name,
-          'description' => $method->comment() ?? null,
-        ];
-      }
+  /** Returns all resources */
+  public function resources(bool $templates): iterable {
+    foreach ($this->delegates as $delegate) {
+      yield from $delegate->resources($templates);
     }
-  }
-
-  protected function contentsOf(string $uri, string $mimeType, $result) {
-    return [
-      ['uri' => $uri, 'mimeType' => $mimeType] + ($result instanceof Bytes
-        ? ['blob' => base64_encode($result)]
-        : ['text' => $result]
-      )
-    ];
   }
 }

--- a/src/main/php/io/modelcontextprotocol/server/ImplementationsIn.class.php
+++ b/src/main/php/io/modelcontextprotocol/server/ImplementationsIn.class.php
@@ -1,11 +1,9 @@
 <?php namespace io\modelcontextprotocol\server;
 
-use lang\MethodNotImplementedException;
 use lang\reflection\Package;
-use util\NoSuchElementException;
 
 /** @test io.modelcontextprotocol.unittest.ImplementationsInTest */
-class ImplementationsIn extends Delegates {
+class ImplementationsIn extends Delegate {
   private $delegates= [];
   private $instances= [];
   private $new;
@@ -27,7 +25,7 @@ class ImplementationsIn extends Delegates {
     }
   }
 
-  public function read($uri) {
+  public function readable($uri) {
     foreach ($this->delegates as $namespace => $type) {
       foreach ($type->methods() as $method) {
         if ($annotation= $method->annotation(Resource::class)) {
@@ -40,17 +38,15 @@ class ImplementationsIn extends Delegates {
         }
       }
     }
-
-    throw new NoSuchElementException($uri);
+    return null;
   }
 
-  public function invoke($tool, $arguments) {
+  public function invokeable($tool) {
     sscanf($tool, '%[^_]_%s', $namespace, $method);
     if (($type= $this->delegates[$namespace] ?? null) && ($reflect= $type->method($method))) {
-      return $reflect->invoke($this->instances[$namespace], (array)$arguments);
+      return fn($arguments) => $reflect->invoke($this->instances[$namespace], $arguments);
     }
-
-    throw new MethodNotImplementedException($tool);
+    return null;
   }
 
   /** Returns all tools */

--- a/src/main/php/io/modelcontextprotocol/server/InstanceDelegate.class.php
+++ b/src/main/php/io/modelcontextprotocol/server/InstanceDelegate.class.php
@@ -1,10 +1,9 @@
 <?php namespace io\modelcontextprotocol\server;
 
-use lang\{Reflection, MethodNotImplementedException};
-use util\NoSuchElementException;
+use lang\Reflection;
 
 /** @test io.modelcontextprotocol.unittest.InstanceDelegateTest */
-class InstanceDelegate extends Delegates {
+class InstanceDelegate extends Delegate {
   private $instance, $type;
   private $namespace= null;
 
@@ -18,7 +17,7 @@ class InstanceDelegate extends Delegates {
     );
   }
 
-  public function read($uri) {
+  public function readable($uri) {
     foreach ($this->type->methods() as $method) {
       if ($annotation= $method->annotation(Resource::class)) {
         $resource= $annotation->newInstance();
@@ -29,17 +28,15 @@ class InstanceDelegate extends Delegates {
         );
       }
     }
-
-    throw new NoSuchElementException($uri);
+    return null;
   }
 
-  public function invoke($tool, $arguments) {
+  public function invokeable($tool) {
     sscanf($tool, $this->namespace.'_%s', $method);
     if ($reflect= $this->type->method($method)) {
-      return $reflect->invoke($this->instance, (array)$arguments);
+      return fn($arguments) => $reflect->invoke($this->instance, $arguments);
     }
-
-    throw new MethodNotImplementedException($tool);
+    return null;
   }
 
   /** Returns all tools */

--- a/src/test/php/io/modelcontextprotocol/unittest/DelegateTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/DelegateTest.class.php
@@ -1,0 +1,110 @@
+<?php namespace io\modelcontextprotocol\unittest;
+
+use test\{Assert, Expect, Test};
+
+abstract class DelegateTest {
+
+  /** @return io.modelcontextprotocol.server.Delegates */
+  protected abstract function fixture();
+
+  #[Test]
+  public function tools() {
+    Assert::equals(
+      [[
+        'name'        => 'greetings_repeat',
+        'description' => 'Repeats a given greeting',
+        'inputSchema' => [
+          'type'       => 'object',
+          'properties' => [
+            'greeting' => ['type' => 'string'],
+            'times'    => ['type' => 'number'],
+          ],
+          'required' => ['greeting', 'times'],
+        ]
+      ]],
+      [...$this->fixture()->tools()]
+    );
+  }
+
+  #[Test]
+  public function prompts() {
+    Assert::equals(
+      [[
+        'name'        => 'greetings_user',
+        'description' => 'Greets users',
+        'arguments' => [
+          [
+            'name'        => 'name',
+            'description' => 'Whom to greet',
+            'required'    => true,
+            'schema'      => ['type' => 'string'],
+          ],
+          [
+            'name'        => 'style',
+            'description' => 'Style',
+            'required'    => false,
+            'schema'      => ['type' => 'string', 'enum' => ['casual', 'friendly']],
+          ],
+        ],
+      ]],
+      [...$this->fixture()->prompts()]
+    );
+  }
+
+  #[Test]
+  public function resources() {
+    Assert::equals(
+      [
+        [
+          'uri'         => 'greeting://default',
+          'name'        => 'greetings_default',
+          'description' => 'Default greeting',
+          'mimeType'    => 'text/plain',
+          'dynamic'     => false,
+        ],
+        [
+          'uri'         => 'greeting://icon',
+          'name'        => 'greetings_icon',
+          'description' => 'Greeting icon',
+          'mimeType'    => 'image/gif',
+          'dynamic'     => true,
+        ]
+      ],
+      [...$this->fixture()->resources(false)]
+    );
+  }
+
+  #[Test]
+  public function resource_templates() {
+    Assert::equals(
+      [[
+        'uriTemplate' => 'greeting://user/{name}',
+        'name'        => 'greetings_get',
+        'description' => 'Dynamic greeting for a user',
+        'mimeType'    => 'text/plain',
+      ]],
+      [...$this->fixture()->resources(true)]
+    );
+  }
+
+  #[Test]
+  public function read_text_resource() {
+    Assert::equals(
+      [['uri' => 'greeting://default', 'mimeType' => 'text/plain', 'text' => 'Hello']],
+      $this->fixture()->readable('greeting://default')
+    );
+  }
+
+  #[Test]
+  public function read_binary_resource() {
+    Assert::equals(
+      [['uri' => 'greeting://icon', 'mimeType' => 'image/gif', 'blob' => 'R0lGODkuLi4=']],
+      $this->fixture()->readable('greeting://icon')
+    );
+  }
+
+  #[Test]
+  public function read_non_existant_resource() {
+    Assert::null($this->fixture()->readable('greeting://non-existant'));
+  }
+}

--- a/src/test/php/io/modelcontextprotocol/unittest/DelegatesTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/DelegatesTest.class.php
@@ -1,42 +1,39 @@
 <?php namespace io\modelcontextprotocol\unittest;
 
-use io\modelcontextprotocol\server\{Delegates, InstanceDelegate, Tool, Param};
+use io\modelcontextprotocol\server\{Delegates, Tool, Param};
 use test\{Assert, Test};
 
 class DelegatesTest extends DelegateTest {
 
   /** @return io.modelcontextprotocol.server.Delegates */
   protected function fixture() {
-    return new Delegates(new InstanceDelegate(new Greetings()));
+    return new Delegates([new Greetings()]);
   }
 
   #[Test]
   public function includes_tools_of_all_delegates() {
-    $basic= new class() {
-      #[Tool]
-      public function add(
-        #[Param(type: 'number')]
-        $a,
-        #[Param(type: 'number')]
-        $b
-      ) {
-        return $a + $b;
+    $fixture= new Delegates([
+      'basic' => new class() {
+        #[Tool]
+        public function add(
+          #[Param(type: 'number')]
+          $a,
+          #[Param(type: 'number')]
+          $b
+        ) {
+          return $a + $b;
+        }
+      },
+      'statistics' => new class() {
+        #[Tool]
+        public function average(
+          #[Param(type: ['type' => 'array', 'items' => 'number'])]
+          $numbers
+        ) {
+          return array_sum($numbers) / sizeof($numbers);
+        }
       }
-    };
-    $statistics= new class() {
-      #[Tool]
-      public function average(
-        #[Param(type: ['type' => 'array', 'items' => 'number'])]
-        $numbers
-      ) {
-        return array_sum($numbers) / sizeof($numbers);
-      }
-    };
-
-    $fixture= new Delegates(
-      new InstanceDelegate($basic, 'basic'),
-      new InstanceDelegate($statistics, 'statistics'),
-    );
+    ]);
 
     Assert::equals(
       [

--- a/src/test/php/io/modelcontextprotocol/unittest/DelegatesTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/DelegatesTest.class.php
@@ -1,111 +1,70 @@
 <?php namespace io\modelcontextprotocol\unittest;
 
-use test\{Assert, Expect, Test};
-use util\NoSuchElementException;
+use io\modelcontextprotocol\server\{Delegates, InstanceDelegate, Tool, Param};
+use test\{Assert, Test};
 
-abstract class DelegatesTest {
+class DelegatesTest extends DelegateTest {
 
   /** @return io.modelcontextprotocol.server.Delegates */
-  protected abstract function fixture();
-
-  #[Test]
-  public function tools() {
-    Assert::equals(
-      [[
-        'name'        => 'greetings_repeat',
-        'description' => 'Repeats a given greeting',
-        'inputSchema' => [
-          'type'       => 'object',
-          'properties' => [
-            'greeting' => ['type' => 'string'],
-            'times'    => ['type' => 'number'],
-          ],
-          'required' => ['greeting', 'times'],
-        ]
-      ]],
-      [...$this->fixture()->tools()]
-    );
+  protected function fixture() {
+    return new Delegates(new InstanceDelegate(new Greetings()));
   }
 
   #[Test]
-  public function prompts() {
-    Assert::equals(
-      [[
-        'name'        => 'greetings_user',
-        'description' => 'Greets users',
-        'arguments' => [
-          [
-            'name'        => 'name',
-            'description' => 'Whom to greet',
-            'required'    => true,
-            'schema'      => ['type' => 'string'],
-          ],
-          [
-            'name'        => 'style',
-            'description' => 'Style',
-            'required'    => false,
-            'schema'      => ['type' => 'string', 'enum' => ['casual', 'friendly']],
-          ],
-        ],
-      ]],
-      [...$this->fixture()->prompts()]
-    );
-  }
+  public function includes_tools_of_all_delegates() {
+    $basic= new class() {
+      #[Tool]
+      public function add(
+        #[Param(type: 'number')]
+        $a,
+        #[Param(type: 'number')]
+        $b
+      ) {
+        return $a + $b;
+      }
+    };
+    $statistics= new class() {
+      #[Tool]
+      public function average(
+        #[Param(type: ['type' => 'array', 'items' => 'number'])]
+        $numbers
+      ) {
+        return array_sum($numbers) / sizeof($numbers);
+      }
+    };
 
-  #[Test]
-  public function resources() {
+    $fixture= new Delegates(
+      new InstanceDelegate($basic, 'basic'),
+      new InstanceDelegate($statistics, 'statistics'),
+    );
+
     Assert::equals(
       [
         [
-          'uri'         => 'greeting://default',
-          'name'        => 'greetings_default',
-          'description' => 'Default greeting',
-          'mimeType'    => 'text/plain',
-          'dynamic'     => false,
+          'name'        => 'basic_add',
+          'description' => null,
+          'inputSchema' => [
+            'type'       => 'object',
+            'properties' => [
+              'a' => ['type' => 'number'],
+              'b' => ['type' => 'number'],
+            ],
+            'required'   => ['a', 'b'],
+          ]
         ],
         [
-          'uri'         => 'greeting://icon',
-          'name'        => 'greetings_icon',
-          'description' => 'Greeting icon',
-          'mimeType'    => 'image/gif',
-          'dynamic'     => true,
-        ]
+          'name'        => 'statistics_average',
+          'description' => null,
+          'inputSchema' => [
+            'type'       => 'object',
+            'properties' => [
+              'numbers' => ['type' => 'array', 'items' => 'number'],
+            ],
+            'required'   => ['numbers'],
+          ]
+        ],
       ],
-      [...$this->fixture()->resources(false)]
+      [...$fixture->tools()]
     );
-  }
-
-  #[Test]
-  public function resource_templates() {
-    Assert::equals(
-      [[
-        'uriTemplate' => 'greeting://user/{name}',
-        'name'        => 'greetings_get',
-        'description' => 'Dynamic greeting for a user',
-        'mimeType'    => 'text/plain',
-      ]],
-      [...$this->fixture()->resources(true)]
-    );
-  }
-
-  #[Test]
-  public function read_text_resource() {
-    Assert::equals(
-      [['uri' => 'greeting://default', 'mimeType' => 'text/plain', 'text' => 'Hello']],
-      $this->fixture()->read('greeting://default')
-    );
-  }
-
-  #[Test]
-  public function read_binary_resource() {
-    Assert::equals(
-      [['uri' => 'greeting://icon', 'mimeType' => 'image/gif', 'blob' => 'R0lGODkuLi4=']],
-      $this->fixture()->read('greeting://icon')
-    );
-  }
-
-  #[Test, Expect(NoSuchElementException::class)]
-  public function read_non_existant_resource() {
-    $this->fixture()->read('greeting://non-existant');
   }
 }

--- a/src/test/php/io/modelcontextprotocol/unittest/ImplementationsInTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/ImplementationsInTest.class.php
@@ -3,10 +3,10 @@
 use io\modelcontextprotocol\server\ImplementationsIn;
 use test\{Assert, Test};
 
-class ImplementationsInTest extends DelegatesTest {
+class ImplementationsInTest extends DelegateTest {
   const PACKAGE= 'io.modelcontextprotocol.unittest';
 
-  /** @return io.modelcontextprotocol.server.Delegates */
+  /** @return io.modelcontextprotocol.server.Delegate */
   protected function fixture() {
     return new ImplementationsIn(self::PACKAGE);
   }

--- a/src/test/php/io/modelcontextprotocol/unittest/InstanceDelegateTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/InstanceDelegateTest.class.php
@@ -3,9 +3,9 @@
 use io\modelcontextprotocol\server\{InstanceDelegate, Tool};
 use test\{Assert, Test};
 
-class InstanceDelegateTest extends DelegatesTest {
+class InstanceDelegateTest extends DelegateTest {
 
-  /** @return io.modelcontextprotocol.server.Delegates */
+  /** @return io.modelcontextprotocol.server.Delegate */
   protected function fixture() {
     return new InstanceDelegate(new Greetings());
   }

--- a/src/test/php/io/modelcontextprotocol/unittest/McpServerTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/McpServerTest.class.php
@@ -46,7 +46,7 @@ class McpServerTest {
   #[Test]
   public function delegates_for_arrays() {
     $list= [new InstanceDelegate($this->delegate), new ImplementationsIn('io.modelcontextprotocol.unittest')];
-    Assert::equals(new Delegates(...$list), (new McpServer($list))->delegate());
+    Assert::equals(new Delegates($list), (new McpServer($list))->delegate());
   }
 
   #[Test]

--- a/src/test/php/io/modelcontextprotocol/unittest/McpServerTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/McpServerTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\modelcontextprotocol\unittest;
 
-use io\modelcontextprotocol\server\{InstanceDelegate, ImplementationsIn};
+use io\modelcontextprotocol\server\{InstanceDelegate, ImplementationsIn, Delegates};
 use io\modelcontextprotocol\{Capabilities, McpServer};
 use lang\FormatException;
 use test\{Assert, Before, Expect, Test};
@@ -33,14 +33,20 @@ class McpServerTest {
   }
 
   #[Test]
-  public function delegates() {
-    $delegates= new ImplementationsIn('io.modelcontextprotocol.unittest');
-    Assert::equals($delegates, (new McpServer($delegates))->delegates());
+  public function delegate_instance() {
+    $delegate= new ImplementationsIn('io.modelcontextprotocol.unittest');
+    Assert::equals($delegate, (new McpServer($delegate))->delegate());
   }
 
   #[Test]
   public function instance_delegate_for_objects() {
-    Assert::equals(new InstanceDelegate($this->delegate), (new McpServer($this->delegate))->delegates());
+    Assert::equals(new InstanceDelegate($this->delegate), (new McpServer($this->delegate))->delegate());
+  }
+
+  #[Test]
+  public function delegates_for_arrays() {
+    $list= [new InstanceDelegate($this->delegate), new ImplementationsIn('io.modelcontextprotocol.unittest')];
+    Assert::equals(new Delegates(...$list), (new McpServer($list))->delegate());
   }
 
   #[Test]


### PR DESCRIPTION
This pull request refactors MCP server delegates to allow for passing multiple delegates as an array.

```php
use io\modelcontextprotocol\server\{Delegates, ImplementationsIn};

// Two instances
new Delegates([new Calculator(), new Statistics()]);

// An instance and all implementatons in the MCP package
new Delegates([new Calculator(), new ImplementationsIn('com.example.mcp')]);

// Two named instances
new Delegates([
  'calculator' => new class() { /* ... */ },
  'statistics' => new class() { /* ... */ },
]);
```