### PR TITLE
Make it possible to supply custom headers along with StreamableHttp

### DIFF
--- a/src/main/php/io/modelcontextprotocol/StreamableHttp.class.php
+++ b/src/main/php/io/modelcontextprotocol/StreamableHttp.class.php
@@ -45,6 +45,21 @@ class StreamableHttp extends Transport {
     $this->endpoint->with(['MCP-Protocol-Version' => $version]);
   }
 
+  /** @return [:string] */
+  public function headers() { return $this->endpoint->headers(); }
+
+  /**
+   * Adds headers to be sent with every request
+   *
+   * @param  string|[:string] $arg
+   * @param  ?string $value
+   * @return self
+   */
+  public function with($arg, $value= null) {
+    $this->endpoint->with($arg, $value);
+    return $this;
+  }
+
   /**
    * Sends a notification
    *

--- a/src/test/php/io/modelcontextprotocol/unittest/StreamableHttpTest.class.php
+++ b/src/test/php/io/modelcontextprotocol/unittest/StreamableHttpTest.class.php
@@ -46,6 +46,32 @@ class StreamableHttpTest {
     return new StreamableHttp(new TestEndpoint($routes, $base));
   }
 
+  #[Test]
+  public function accepts_json_and_event_stream_by_default() {
+    Assert::equals(
+      'text/event-stream, application/json',
+      (new StreamableHttp('https://example.com/'))->headers()['Accept']
+    );
+  }
+
+  #[Test]
+  public function pass_header() {
+    $token= 'Token test';
+    Assert::equals($token, (new StreamableHttp('https://example.com/'))
+      ->with('Authorization', $token)
+      ->headers()['Authorization']
+    );
+  }
+
+  #[Test]
+  public function pass_headers() {
+    $token= 'Token test';
+    Assert::equals($token, (new StreamableHttp('https://example.com/'))
+      ->with(['Authorization' => $token])
+      ->headers()['Authorization']
+    );
+  }
+
   #[Test, Values(['application/json', 'application/json; charset=utf-8'])]
   public function json($type) {
     $value= ['name' => 'test', 'version' => '1.0.0'];


### PR DESCRIPTION
Example:

```php
use io\modelcontextprotocol\{McpClient, StreamableHttp};
use util\cmd\Console;

$client= new McpClient(new StreamableHttp($argv[1])->with(['Authorization' => 'Token '.$argv[2]]));

// Initialize
$init= $client->initialize();
Console::writeLine('=> Connected to ', $argv[1], ': ', $init);

// Fetch tool list
$response= $client->call('tools/list');
Console::writeLine($response->value());
```